### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Run the application locally with:
 rails s
 ```
 
-##Rule of the Game
+## Rule of the Game
 Once you have the application set up, you can:
 
 * Login using your Pivotal Tracker credential


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
